### PR TITLE
Fix /tmp not writable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG GIT_SHA
 ARG GIT_NAME
 
-FROM golang:1.19 AS runj
+FROM golang:1.19-bullseye AS runj
 WORKDIR /usr/src/app/
 COPY runj/go.mod runj/go.sum ./
 RUN go mod download && go mod verify

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM golang:1.19 AS runj
+FROM golang:1.19-bullseye AS runj
 WORKDIR /usr/src/app/
 COPY runj/go.mod runj/go.sum ./
 RUN go mod download && go mod verify

--- a/runj/cmd/runj/execute/spec.go
+++ b/runj/cmd/runj/execute/spec.go
@@ -46,6 +46,12 @@ var defaultMountPoints = []specs.Mount{
 		Source:      "sysfs",
 		Options:     []string{"nosuid", "noexec", "nodev", "ro"},
 	},
+	{
+		Destination: "/tmp",
+		Type:        "tmpfs",
+		Source:      "tmpfs",
+		Options:     []string{"nosuid", "nodev"},
+	},
 }
 
 func makeContainerSpec(config *entities.RunjConfig, uidMappings []specs.LinuxIDMapping, gidMappings []specs.LinuxIDMapping) (*specs.Spec, error) {

--- a/runj/cmd/runj/execute/spec.go
+++ b/runj/cmd/runj/execute/spec.go
@@ -50,7 +50,7 @@ var defaultMountPoints = []specs.Mount{
 		Destination: "/tmp",
 		Type:        "tmpfs",
 		Source:      "tmpfs",
-		Options:     []string{"nosuid", "nodev"},
+		Options:     []string{"nosuid", "noexec", "nodev", "size=128m", "nr_inodes=4k"},
 	},
 }
 


### PR DESCRIPTION
In the sandbox, `/tmp` is a directory owned by `nobody` with permission `rwxrwxrwt`. This prevents programs in the sandbox from writing to `/tmp`, causing problems with programs like GCC.

To solve this problem, I mount `/tmp` as tmpfs, which may improve performance while solving this permission issues.