### PR TITLE
Remove runj dirty hack

### DIFF
--- a/runj/cmd/runj/execute/utils.go
+++ b/runj/cmd/runj/execute/utils.go
@@ -18,12 +18,12 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func initContainerFactory() (libcontainer.Factory, error) {
+func initContainerFactory(overlayfsConfig string) (libcontainer.Factory, error) {
 	return libcontainer.New(
 		".",
 		libcontainer.NewuidmapPath("/usr/bin/newuidmap"),
 		libcontainer.NewgidmapPath("/usr/bin/newgidmap"),
-		libcontainer.InitArgs(os.Args[0], "init"),
+		libcontainer.InitArgs(os.Args[0], "init", overlayfsConfig),
 	)
 }
 
@@ -142,7 +142,7 @@ func prepareFds(config *entities.FdConfig) (*os.File, *os.File, *os.File, error)
 func prepareOutFd(stdout bool, config *entities.FdConfig) (*os.File, error) {
 	if config == nil || (stdout && config.StdOut == "") || (!stdout && config.StdErr == "") {
 		mask := unix.Umask(0)
-		file, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0664)
+		file, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0o664)
 		unix.Umask(mask)
 		if err != nil {
 			return nil, fmt.Errorf("Error opening the %s: %w", os.DevNull, err)
@@ -157,7 +157,7 @@ func prepareOutFd(stdout bool, config *entities.FdConfig) (*os.File, error) {
 		}
 
 		mask := unix.Umask(0)
-		file, err := os.OpenFile(path, modes, 0664)
+		file, err := os.OpenFile(path, modes, 0o664)
 		unix.Umask(mask)
 		if err != nil {
 			return nil, fmt.Errorf("Error opening the file: %w", err)

--- a/runj/cmd/runj/main.go
+++ b/runj/cmd/runj/main.go
@@ -24,7 +24,7 @@ import (
 func init() {
 	runtime.GOMAXPROCS(1)
 
-	if len(os.Args) > 1 && os.Args[1] == "init" {
+	if len(os.Args) > 2 && os.Args[1] == "init" {
 		runtime.LockOSThread()
 
 		if err := utils.SetupOverlayfs(); err != nil {

--- a/runj/cmd/runj/utils/overlayfs.go
+++ b/runj/cmd/runj/utils/overlayfs.go
@@ -10,7 +10,7 @@ import (
 )
 
 func SetupOverlayfs() error {
-	configJson := os.Getenv("GOMAXPROCS")
+	configJson := os.Args[2]
 	if configJson == "" {
 		return fmt.Errorf("Unexpected empty overlayfs config")
 	}


### PR DESCRIPTION
代码里原来在用改环境变量的方式传 runj 参数，但是这东西其实是可以直接传命令行的时候顺便拿过来的，看了下 libcontainer 发现里边的实现并不依赖 args 必须有只一个值．跑了下 runj 底下的那几个恶意代码 test 也能通过．
