### PR TITLE
fix: use user name to find subgid

### DIFF
--- a/src/conf/action.rs
+++ b/src/conf/action.rs
@@ -90,9 +90,6 @@ pub struct ActionRunContainerConfig {
     #[serde(default = "default_userns_gid")]
     pub userns_gid: u32,
 
-    #[serde(default = "default_userns_group")]
-    pub userns_group: String,
-
     #[serde(default)]
     pub preload_images: Vec<OciImage>,
 
@@ -111,7 +108,6 @@ impl Default for ActionRunContainerConfig {
             userns_uid: default_userns_uid(),
             userns_user: default_userns_user(),
             userns_gid: default_userns_gid(),
-            userns_group: default_userns_group(),
             preload_images: Default::default(),
             cache_size_mib: default_cache_size_mib(),
             cache_ttl_hour: default_cache_ttl_hour(),
@@ -145,12 +141,4 @@ fn default_userns_user() -> String {
 #[inline]
 fn default_userns_gid() -> u32 {
     users::get_effective_gid()
-}
-
-#[inline]
-fn default_userns_group() -> String {
-    users::get_current_groupname()
-        .expect("Failed to get current group name")
-        .into_string()
-        .expect("Failed to convert the group name")
 }

--- a/src/worker/action/run_container/idmap.rs
+++ b/src/worker/action/run_container/idmap.rs
@@ -17,7 +17,7 @@ pub static SUBUIDS: Lazy<SubIds> = Lazy::new(|| {
 });
 
 pub static SUBGIDS: Lazy<SubIds> = Lazy::new(|| {
-    get_subgids(&conf::CONFIG.worker.action.run_container.userns_group)
+    get_subgids(&conf::CONFIG.worker.action.run_container.userns_user)
         .expect("Error getting subgids")
 });
 


### PR DESCRIPTION
当 config.toml 里用户名和组名不相同时会报错，经过查阅文档发现 /etc/subgid 第一列的值是 uid 或用户名而不是组名．

https://www.man7.org/linux/man-pages/man5/subgid.5.html